### PR TITLE
Skip avatars in images sitemap provided by Jetpack

### DIFF
--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -16,3 +16,26 @@
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */
+
+/**
+ * Require Jetpack_Compat class
+ */
+require_once __DIR__ . '/includes/jetpack-compat/class-jetpack-compat.php';
+
+/**
+ * Init Jetpack Compat
+ */
+function cata_cap_init_jetpack_compat() : void {
+	global $cata_cap_jetpack_compat;
+	$cata_cap_jetpack_compat = cata_cap_jetpack_compat();
+}
+add_action( 'init', 'cata_cap_init_jetpack_compat' );
+
+/**
+ * Jetpack Compat
+ * 
+ * @return Cata\CoAuthors_Plus\Jetpack_Compat
+ */
+function cata_cap_jetpack_compat() : Cata\CoAuthors_Plus\Jetpack_Compat {
+	return Cata\CoAuthors_Plus\Jetpack_Compat::instance();
+}

--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -22,20 +22,4 @@
  */
 require_once __DIR__ . '/includes/jetpack-compat/class-jetpack-compat.php';
 
-/**
- * Init Jetpack Compat
- */
-function cata_cap_init_jetpack_compat() : void {
-	global $cata_cap_jetpack_compat;
-	$cata_cap_jetpack_compat = cata_cap_jetpack_compat();
-}
-add_action( 'init', 'cata_cap_init_jetpack_compat' );
-
-/**
- * Jetpack Compat
- * 
- * @return Cata\CoAuthors_Plus\Jetpack_Compat
- */
-function cata_cap_jetpack_compat() : Cata\CoAuthors_Plus\Jetpack_Compat {
-	return Cata\CoAuthors_Plus\Jetpack_Compat::instance();
-}
+Cata\CoAuthors_Plus\Jetpack_Compat::instance();

--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -22,4 +22,4 @@
  */
 require_once __DIR__ . '/includes/jetpack-compat/class-jetpack-compat.php';
 
-Cata\CoAuthors_Plus\Jetpack_Compat::instance();
+new Cata\CoAuthors_Plus\Jetpack_Compat();

--- a/includes/jetpack-compat/class-jetpack-compat.php
+++ b/includes/jetpack-compat/class-jetpack-compat.php
@@ -11,31 +11,11 @@ namespace Cata\CoAuthors_Plus;
  * Jetpack Compat
  */
 class Jetpack_Compat {
-	
-	/**
-	 * Singleton Instance
-	 *
-	 * @var null|self $instance
-	 */
-	private static $instance = null;
-	
 	/**
 	 * Construct
 	 */
 	public function __construct() {
 		add_filter( 'jetpack_sitemap_image_skip_post', array( __CLASS__, 'image_sitemap_skip_avatars' ), 10, 2 );
-	}
-
-	/**
-	 * Instance
-	 * 
-	 * @return Jetpack_Compat
-	 */
-	public static function instance() : Jetpack_Compat {
-		if ( null === self::$instance ) {
-			self::$instance = new Jetpack_Compat();
-		}
-		return self::$instance;
 	}
 
 	/**

--- a/includes/jetpack-compat/class-jetpack-compat.php
+++ b/includes/jetpack-compat/class-jetpack-compat.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Jetpack Compat
+ * 
+ * @package Cata\CoAuthors_Plus
+ */
+
+namespace Cata\CoAuthors_Plus;
+
+/**
+ * Jetpack Compat
+ */
+class Jetpack_Compat {
+	
+	/**
+	 * Singleton Instance
+	 *
+	 * @var null|self $instance
+	 */
+	private static $instance = null;
+	
+	/**
+	 * Construct
+	 */
+	public function __construct() {
+		add_filter( 'jetpack_sitemap_image_skip_post', array( __CLASS__, 'image_sitemap_skip_avatars' ), 10, 2 );
+	}
+
+	/**
+	 * Instance
+	 * 
+	 * @return Jetpack_Compat
+	 */
+	public static function instance() : Jetpack_Compat {
+		if ( null === self::$instance ) {
+			self::$instance = new Jetpack_Compat();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Image Sitemap Skip Avatars
+	 * In the images sitemap, avatars produce URLs like `/?post_type=guest-author&p=7947` for their parent post.
+	 * These lead to 404s and search indexing errors in Google Search Console.
+	 *
+	 * @param bool             $skip Whether to skip this entry in the sitemap.
+	 * @param stdClass|WP_Post $post Post we're examining - can be stdClass for some reason.
+	 * @return bool $skip Whether to skip this entry in the sitemap.
+	 */
+	public static function image_sitemap_skip_avatars( bool $skip, $post ) : bool {
+		if ( ! is_object( $post ) || ! property_exists( $post, 'post_parent' ) ) {
+			return $skip;
+		}
+
+		$parent_id = absint( $post->post_parent );
+
+		if ( 0 === $parent_id ) {
+			return $skip;
+		}
+
+		if ( 'guest-author' === get_post_type( $parent_id ) ) {
+			return true;
+		}
+
+		return $skip;
+	}
+}


### PR DESCRIPTION
### Related Issues

- Resolves #1 

### What Was Accomplished

- Added `Jetpack_Compat` PHP class which includes an action on `jetpack_sitemap_image_skip_post` to skip the Guest Author avatars.
- Updated the main plugin file to instantiate Jetpack_Compat.