### PR TITLE
Remove old messaging platforms from Guest Author profiles

### DIFF
--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -18,8 +18,13 @@
  */
 
 /**
- * Require Jetpack_Compat class
+ * Require classes
  */
 require_once __DIR__ . '/includes/jetpack-compat/class-jetpack-compat.php';
+require_once __DIR__ . '/includes/fields/class-fields.php';
 
+/**
+ * Instantiate Classes
+ */
+new Cata\CoAuthors_Plus\Fields();
 new Cata\CoAuthors_Plus\Jetpack_Compat();

--- a/includes/fields/class-fields.php
+++ b/includes/fields/class-fields.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Fields
+ * 
+ * @package Cata\CoAuthors_Plus
+ */
+
+namespace Cata\CoAuthors_Plus;
+
+/**
+ * Fields
+ */
+class Fields {
+	/**
+	 * Field to Remove
+	 * 
+	 * @var array $fields_to_remove
+	 */
+	private static $fields_to_remove = array(
+		'aim',
+		'yahooim',
+		'jabber',
+	);
+
+	/**
+	 * Construct
+	 */
+	public function __construct() {
+		add_filter( 'coauthors_guest_author_fields', array( __CLASS__, 'remove_unused_meta_fields' ), 10, 2 );
+	}
+
+	/**
+	 * Remove Unused Meta Fields
+	 * 
+	 * @param array $fields_to_return Provided array of fields CAP is looking for.
+	 * @return array Updated array of fields CAP should return.
+	 */
+	public static function remove_unused_meta_fields( array $fields_to_return ) : array {
+		return array_values(
+			array_filter(
+				$fields_to_return,
+				array( __CLASS__, 'should_keep_field' )
+			)
+		);
+	}
+
+	/**
+	 * Should Keep Field?
+	 *
+	 * @param array $field Field we might want CAP to return.
+	 * @return bool Whether this is a field to keep, by virture of NOT being a $field_to_remove.
+	 */
+	public static function should_keep_field( array $field ) : bool {
+		return ! in_array( $field['key'], self::$fields_to_remove, true );
+	}
+}


### PR DESCRIPTION
### Related Issues

- Resolves #2 

### What Was Accomplished

- Added a PHP class based on the examples in the issue to remove unwanted fields from CAP Guest Author profiles.

### Screenshots

Profile editor without AIM, Yahoo or Jabber

<img width="631" alt="Screen Shot 2021-09-09 at 2 12 24 PM" src="https://user-images.githubusercontent.com/226381/132740633-e09cfef5-cb2b-43ef-ba1b-6c63414e86b9.png">
