### PR TITLE
Add Instagram, Twitter and TikTok to Guest Author Profiles

### DIFF
--- a/includes/fields/class-fields.php
+++ b/includes/fields/class-fields.php
@@ -92,5 +92,4 @@ class Fields {
 
 		return array_merge( $fields_to_return, $new_fields );
 	}
-
 }

--- a/includes/fields/class-fields.php
+++ b/includes/fields/class-fields.php
@@ -26,7 +26,8 @@ class Fields {
 	 * Construct
 	 */
 	public function __construct() {
-		add_filter( 'coauthors_guest_author_fields', array( __CLASS__, 'remove_unused_meta_fields' ), 10, 2 );
+		add_filter( 'coauthors_guest_author_fields', array( __CLASS__, 'remove_unused_meta_fields' ) );
+		add_filter( 'coauthors_guest_author_fields', array( __CLASS__, 'add_custom_meta_fields' ), 20, 2 );
 	}
 
 	/**
@@ -53,4 +54,43 @@ class Fields {
 	public static function should_keep_field( array $field ) : bool {
 		return ! in_array( $field['key'], self::$fields_to_remove, true );
 	}
+
+	/**
+	 * Add Custom Meta Fields
+	 * 
+	 * @param array $fields_to_return Provided array of fields CAP is looking for.
+	 * @param array $groups Groups of fields CAP is looking for. Don't add fields if their group hasn't been requested.
+	 * @return array Updated array of fields.
+	 */
+	public static function add_custom_meta_fields( array $fields_to_return, array $groups ) : array {
+		// Everything is in contact-info for now.
+		// Accept all and contact-info.
+		if ( ! in_array( 'all', $groups, true ) && ! in_array( 'contact-info', $groups, true ) ) {
+			return $fields_to_return;
+		}
+
+		$new_fields = array(
+			array(
+				'key'               => 'instagram',
+				'label'             => 'Instagram URL',
+				'group'             => 'contact-info',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			array(
+				'key'               => 'tiktok',
+				'label'             => 'TikTok URL',
+				'group'             => 'contact-info',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			array(
+				'key'               => 'twitter',
+				'label'             => 'Twitter URL',
+				'group'             => 'contact-info',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+		);
+
+		return array_merge( $fields_to_return, $new_fields );
+	}
+
 }


### PR DESCRIPTION
### Related Issues

- Resolves #3 

### What Was Accomplished

- Added a filter on `coauthors_guest_author_fields` to append our custom fields.
  - Checked the requested field `$groups` before appending so the data is only applied in the right context.