### PR TITLE
Wrap CAP's get_the_coauthor_meta to return a single value

### DIFF
--- a/includes/global-functions.php
+++ b/includes/global-functions.php
@@ -67,9 +67,9 @@ function cata_cap_has_global_guest_author() : bool {
  * Wrap get_the_coauthor_meta that comes with CAP to return a useable value,
  * not an array of values.
  * 
- * @param string                 $property CoAuthor data we want.
- * @param stdClass|WP_User|false $author CoAuthor that is either a user or Guest Author.
- * @param mixed                  $default Default if that property is not set.
+ * @param string           $property CoAuthor data we want.
+ * @param stdClass|WP_User $author CoAuthor that is either a user or Guest Author.
+ * @param mixed            $default Default if that property is not set.
  * @return mixed Property or default.
  */
 function cata_cap_get_the_coauthor_meta( string $property, $author, $default = '' ) {

--- a/includes/global-functions.php
+++ b/includes/global-functions.php
@@ -61,3 +61,21 @@ function cata_cap_has_global_guest_author() : bool {
 		cata_cap_get_global_guest_author()
 	);
 }
+
+/**
+ * Get The CoAuthor Meta
+ * Wrap get_the_coauthor_meta that comes with CAP to return a useable value,
+ * not an array of values.
+ * 
+ * @param string                 $property CoAuthor data we want.
+ * @param stdClass|WP_User|false $author CoAuthor that is either a user or Guest Author.
+ * @param mixed                  $default Default if that property is not set.
+ * @return mixed Property or default.
+ */
+function cata_cap_get_the_coauthor_meta( string $property, $author, $default = '' ) {
+	$cap_meta = get_the_coauthor_meta( $property, $author->ID );
+	if ( ! isset( $cap_meta[$author->ID] ) || empty( $cap_meta[$author->ID] ) ) {
+		return $default;
+	}
+	return $cap_meta[$author->ID];
+}


### PR DESCRIPTION
### Related Issues

- Resolves #4 

### What Was Accomplished

- Added `cata_cap_get_the_coauthor_meta` which wraps `get_the_coauthor_meta` to simplify the returned value.
