### PR TITLE
Support WP_User or false results from get_coauthor_by

### DIFF
--- a/includes/global-functions.php
+++ b/includes/global-functions.php
@@ -21,7 +21,7 @@ function cata_cap_safe_get_object_property( string $property, $object, $default 
 	if ( ! is_object( $object ) ) {
 		return $default;
 	}
-	if ( ! property_exists( $object, $property ) ) {
+	if ( ! isset( $object->{$property} ) ) {
 		return $default;
 	}
 	return $object->{$property};
@@ -43,7 +43,7 @@ function cata_cap_is_guest_author( $author ) : bool {
  * @global CoAuthors_Plus $coauthors_plus Instance of CoAuthors_Plus.
  * @return stdClass|WP_User|false Result of `$coauthors_plus->get_coauthor_by`
  */
-function cata_cap_get_global_guest_author() {
+function cata_cap_get_queried_coauthor() {
 	global $coauthors_plus;
 	return $coauthors_plus->get_coauthor_by(
 		'user_nicename',
@@ -52,30 +52,23 @@ function cata_cap_get_global_guest_author() {
 }
 
 /**
- * Has Global Guest Author
+ * Has Queried CoAuthor
  * 
- * @return bool Whether the author referred to be the query var `author_name` is a Guest Author.
+ * @return bool Whether the coauthor referred to be the query var `author_name` was found.
  */
-function cata_cap_has_global_guest_author() : bool {
-	return cata_cap_is_guest_author(
-		cata_cap_get_global_guest_author()
-	);
+function cata_cap_has_queried_coauthor() : bool {
+	$author = cata_cap_get_queried_coauthor();
+	return cata_cap_is_guest_author( $author ) || is_a( $author, 'WP_User' );
 }
 
 /**
  * Get The CoAuthor Meta
- * Wrap get_the_coauthor_meta that comes with CAP to return a useable value,
- * not an array of values.
  * 
- * @param string           $property CoAuthor data we want.
- * @param stdClass|WP_User $author CoAuthor that is either a user or Guest Author.
- * @param mixed            $default Default if that property is not set.
+ * @param string                 $property CoAuthor data we want.
+ * @param stdClass|WP_User|false $author CoAuthor that is either a user or Guest Author.
+ * @param mixed                  $default Default if that property is not set.
  * @return mixed Property or default.
  */
 function cata_cap_get_the_coauthor_meta( string $property, $author, $default = '' ) {
-	$cap_meta = get_the_coauthor_meta( $property, $author->ID );
-	if ( ! isset( $cap_meta[$author->ID] ) || empty( $cap_meta[$author->ID] ) ) {
-		return $default;
-	}
-	return $cap_meta[$author->ID];
+	return cata_cap_safe_get_object_property( $property, $author, $default );
 }


### PR DESCRIPTION
### Related Issues

- #4 and #5
- These changes are based on the testing the plugin with a real theme.

### What Was Accomplished

- Updated `cata_cap_safe_get_object_property` to use `isset` instead of `property_exists` because it works for both `stdClass` and `WP_User` which uses a custom `__get` method to get properties out of a data object.
- Updated `get_global_guest_author` and `has_global_guest_author` to `*_queried_coauthor` so they include WP_User objects as well.
  - This is different from the example site mentioned in the issue where we specifically needed to exclude users.
- Updated `cata_cap_get_the_coauthor_meta` to use `cata_cap_safe_get_object_property` as originally intended which provides support if `$coauthors_plus->get_coauthor_by` returns false.

### References
- https://core.trac.wordpress.org/browser/tags/5.8/src/wp-includes/class-wp-user.php#L302