### PR TITLE
Add Support for CoAuthors in RSS Feeds

### DIFF
--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -27,9 +27,11 @@ require_once __DIR__ . '/includes/global-functions.php';
  */
 require_once __DIR__ . '/includes/jetpack-compat/class-jetpack-compat.php';
 require_once __DIR__ . '/includes/fields/class-fields.php';
+require_once __DIR__ . '/includes/rss/class-rss.php';
 
 /**
  * Instantiate Classes
  */
 new Cata\CoAuthors_Plus\Fields();
 new Cata\CoAuthors_Plus\Jetpack_Compat();
+new Cata\CoAuthors_Plus\RSS();

--- a/includes/rss/class-rss.php
+++ b/includes/rss/class-rss.php
@@ -38,7 +38,7 @@ class RSS {
 		}
 
 		// Bail if the current post type does not support CoAuthors.
-		if ( ! in_array( get_post_type( get_the_ID() ), $coauthors_plus->supported_post_types ) ) {
+		if ( ! in_array( get_post_type( get_the_ID() ), $coauthors_plus->supported_post_types, true ) ) {
 			return $author;
 		}
 

--- a/includes/rss/class-rss.php
+++ b/includes/rss/class-rss.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * RSS
+ * 
+ * @package Cata\CoAuthors_Plus
+ * @since 0.2.1
+ */
+
+namespace Cata\CoAuthors_Plus;
+
+/**
+ * RSS
+ */
+class RSS {
+	/**
+	 * Construct
+	 */
+	public function __construct() {
+		add_filter( 'the_author', array( __CLASS__, 'use_coauthors' ), 100 );
+	}
+
+	/**
+	 * Use CoAuthors
+	 * 
+	 * @link https://danielbachhuber.com/2011/12/13/co-authors-in-your-rss-feeds/
+	 * @param string $author Default author name.
+	 * @return string Updated author name(s).
+	 */
+	public static function use_coauthors( ?string $author ) : string {
+		global $coauthors_plus;
+
+		if ( ! is_feed() || ! function_exists( 'coauthors' ) ) {
+			return $author;
+		}
+
+		if ( ! is_a( $coauthors_plus, 'CoAuthors_Plus' ) ) {
+			return $author;
+		}
+
+		// Bail if the current post type does not support CoAuthors.
+		if ( ! in_array( get_post_type( get_the_ID() ), $coauthors_plus->supported_post_types ) ) {
+			return $author;
+		}
+
+		return coauthors( null, null, null, null, false );
+	}
+}


### PR DESCRIPTION
### Related Issues

- Resolves #13 

### What Was Accomplished

- Added RSS PHP class.
- Added filter on `the_author` that replaces the string value with the CoAuthors if the following criteria are met:
  - `coauthors` function exists
  - `global $coauthors_plus` is an instance of `CoAuthors_Plus`
  - The current post type is included in `$coauthors_plus->supported_post_types`

### How It Was Tested

- I tested the check on `supported_post_types` using a feed of WooCommerce products, which do not support CoAuthors by default.
