### PR TITLE
Use CoAuthors Plus through REST API

### DIFF
--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -12,7 +12,7 @@
  * Description: Common functions, configuration and compatibility fixes for Co-Authors Plus when used in Cata child themes. Not a fork or replacement for CAP.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.2.1
+ * Version:     0.2.2-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -25,6 +25,7 @@ require_once __DIR__ . '/includes/global-functions.php';
 /**
  * Require classes
  */
+require_once __DIR__ . '/includes/api/class-api.php';
 require_once __DIR__ . '/includes/jetpack-compat/class-jetpack-compat.php';
 require_once __DIR__ . '/includes/fields/class-fields.php';
 require_once __DIR__ . '/includes/rss/class-rss.php';
@@ -32,6 +33,7 @@ require_once __DIR__ . '/includes/rss/class-rss.php';
 /**
  * Instantiate Classes
  */
+new Cata\CoAuthors_Plus\API();
 new Cata\CoAuthors_Plus\Fields();
 new Cata\CoAuthors_Plus\Jetpack_Compat();
 new Cata\CoAuthors_Plus\RSS();

--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -26,6 +26,8 @@ require_once __DIR__ . '/includes/global-functions.php';
  * Require classes
  */
 require_once __DIR__ . '/includes/api/class-api.php';
+require_once __DIR__ . '/includes/api/coauthor-controller/class-coauthor-controller.php';
+require_once __DIR__ . '/includes/api/guest-author-controller/class-guest-author-controller.php';
 require_once __DIR__ . '/includes/jetpack-compat/class-jetpack-compat.php';
 require_once __DIR__ . '/includes/fields/class-fields.php';
 require_once __DIR__ . '/includes/rss/class-rss.php';

--- a/includes/api/class-api.php
+++ b/includes/api/class-api.php
@@ -10,6 +10,9 @@ namespace Cata\CoAuthors_Plus;
 
 use WP_REST_Request;
 
+/**
+ * API
+ */
 class API {
 	/**
 	 * Construct
@@ -25,10 +28,11 @@ class API {
 	/**
 	 * Update Taxonomy Args
 	 * 
-	 * @param array $args
-	 * @param string $taxonomy
+	 * @param array  $args Provided taxonomy registration args.
+	 * @param string $taxonomy The name of the taxonomy being registered.
+	 * @return array Updated args for REST API inclusion.
 	 */
-	public static function update_taxonomy_args( array $args, string $taxonomy ) {
+	public static function update_taxonomy_args( array $args, string $taxonomy ) : array {
 		global $coauthors_plus;
 		if ( $coauthors_plus->coauthor_taxonomy !== $taxonomy ) {
 			return $args;
@@ -36,10 +40,10 @@ class API {
 		return array_merge(
 			$args,
 			array(
-				// Needs its own rest base because 'author' is taken.
+				// Needs its own REST base because 'author' is taken.
 				'rest_base'             => 'coauthor',
 				'rest_controller_class' => 'Cata\\CoAuthors_Plus\\API\\CoAuthor_Controller',
-				'show_in_rest'          => true
+				'show_in_rest'          => true,
 			)
 		);
 	}
@@ -47,12 +51,13 @@ class API {
 	/**
 	 * Update Post Type Args
 	 * 
-	 * @param array $args
-	 * @param string $post_type
+	 * @param array  $args Provided post type registration args.
+	 * @param string $post_type The post type being registered.
+	 * @return array Args updated for REST API inclusion.
 	 */
 	public static function update_post_type_args( array $args, string $post_type ) : array {
 		// Tried to get this from CoAuthors_Guest_Authors,
-		// but couldn't access it through global $coauthors_plus
+		// but couldn't access it through global $coauthors_plus.
 		if ( 'guest-author' !== $post_type ) {
 			return $args;
 		}
@@ -60,8 +65,8 @@ class API {
 			$args,
 			array(
 				'rest_controller_class' => 'Cata\\CoAuthors_Plus\\API\\Guest_Author_Controller',
-				'show_in_rest' => true,
-				'supports'     => array_merge(
+				'show_in_rest'          => true,
+				'supports'              => array_merge(
 					$args['supports'],
 					array( 'custom-fields' )
 				),
@@ -84,7 +89,7 @@ class API {
 			'cap-description',
 			'cap-instagram',
 			'cap-tiktok',
-			'cap-twitter'
+			'cap-twitter',
 		);
 
 		foreach ( $meta_keys as $meta_key ) {
@@ -93,7 +98,6 @@ class API {
 				$meta_key,
 				array(
 					// Auth prevents unauthorized editing and deleting, not reading.
-					// Might not need this if we restrict reading the Tax and Post Type.
 					'auth_callback'     => array( __CLASS__, 'current_user_has_cap_cap' ),
 					'sanitize_callback' => 'sanitize_text_field',
 					'single'            => true,
@@ -107,7 +111,7 @@ class API {
 	/**
 	 * Remove Custom Fields Box
 	 * Custom Fields must be enabled to get meta data into the API,
-	 * but we don't actually want it to be editing directly in the post editor.
+	 * but we don't actually want it to be edited directly in the post editor.
 	 */
 	public static function remove_cutstom_fields_box() : void {
 		remove_meta_box( 'postcustom', 'guest-author', 'normal' );
@@ -137,13 +141,13 @@ class API {
 	 * 
 	 * @link https://developer.wordpress.org/reference/hooks/rest_this-post_type_query/
 	 * @link https://gist.github.com/maheshwaghmare/0bbe5eabceed24aa76ef1eabe684a748
-	 * @param array $args Initial query args.
-	 * @param WP_REST_Request $request
+	 * @param array           $args Initial query args.
+	 * @param WP_REST_Request $request API request being handled.
 	 * @return array $args Updated query args.
 	 */
 	public static function post_meta_request_params( array $args, WP_REST_Request $request ) {
 		// Only allowed for users who can edit Guest Authors.
-		// This might be redundant since viewing requires capabilities check.
+		// This is a redundant auth check, in case the read capability ever changes.
 		if ( ! self::current_user_has_cap_cap() ) {
 			return $args;
 		}
@@ -151,11 +155,11 @@ class API {
 		if ( ! isset( $request['meta_key'] ) || 'cap-user_email' !== $request['meta_key'] ) {
 			return $args;
 		}
-
 		return array_merge(
 			$args,
 			array(
 				'meta_key'   => $request['meta_key'],
+				// @phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 				'meta_value' => $request['meta_value'],
 			)
 		);

--- a/includes/api/class-api.php
+++ b/includes/api/class-api.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * API
+ * 
+ * @package Cata\CoAuthors_Plus
+ */
+
+namespace Cata\CoAuthors_Plus;
+
+class API {
+	/**
+	 * Construct
+	 */
+	public function __construct() {
+		add_filter( 'register_taxonomy_args', array( __CLASS__, 'update_taxonomy_args' ), 10, 2 );
+		add_filter( 'register_post_type_args', array( __CLASS__, 'update_post_type_args' ), 10, 2 );
+		add_action( 'init', array( __CLASS__, 'register_guest_author_meta' ) );
+		add_action( 'do_meta_boxes', array( __CLASS__, 'remove_cutstom_fields_box' ), 10, 0 );
+		add_filter( 'rest_guest-author_query', array( __CLASS__, 'post_meta_request_params' ), 10, 2 );
+	}
+
+	/**
+	 * Update Taxonomy Args
+	 * 
+	 * @param array $args
+	 * @param string $taxonomy
+	 */
+	public static function update_taxonomy_args( array $args, string $taxonomy ) {
+		global $coauthors_plus;
+		if ( $coauthors_plus->coauthor_taxonomy !== $taxonomy ) {
+			return $args;
+		}
+		return array_merge(
+			$args,
+			array(
+				'show_in_rest' => true,
+			)
+		);
+	}
+
+	/**
+	 * Update Post Type Args
+	 * 
+	 * @param array $args
+	 * @param string $post_type
+	 */
+	public static function update_post_type_args( array $args, string $post_type ) : array {
+		// Tried to get this from CoAuthors_Guest_Authors,
+		// but couldn't access it through global $coauthors_plus
+		if ( 'guest-author' !== $post_type ) {
+			return $args;
+		}
+		return array_merge(
+			$args,
+			array(
+				'show_in_rest' => true,
+				'supports'     => array_merge(
+					$args['supports'],
+					array( 'custom-fields' )
+				),
+			)
+		);
+	}
+
+	/**
+	 * Register Guest Author Meta
+	 */
+	public static function register_guest_author_meta() : void {
+
+		$meta_keys = array(
+			'cap-display_name',
+			'cap-first_name',
+			'cap-last_name',
+			'cap-user_email',
+			'cap-user_login',
+			'cap-website',
+			'cap-description',
+			'cap-instagram',
+			'cap-tiktok',
+			'cap-twitter'
+		);
+
+		foreach ( $meta_keys as $meta_key ) {
+			register_post_meta(
+				'guest-author',
+				$meta_key,
+				array(
+					'sanitize_callback' => 'sanitize_text_field',
+					'single'            => true,
+					'show_in_rest'      => true,
+					'type'              => 'string',
+				)
+			);
+		}
+	}
+
+	/**
+	 * Remove Custom Fields Box
+	 * Custom Fields must be enabled to get meta data into the API,
+	 * but we don't actually want it to be editing directly in the post editor.
+	 */
+	public static function remove_cutstom_fields_box() : void {
+		remove_meta_box( 'postcustom', 'guest-author', 'normal' );
+	}
+
+	/**
+	 * @link https://gist.github.com/maheshwaghmare/0bbe5eabceed24aa76ef1eabe684a748
+	 */
+	public static function post_meta_request_params( $args, $request ) {
+		
+		$args = array_merge(
+			$args,
+			array(
+				'meta_key'   => $request['meta_key'],
+				'meta_value' => $request['meta_value'],
+			)
+		);
+
+		return $args;
+	}
+}

--- a/includes/api/class-api.php
+++ b/includes/api/class-api.php
@@ -36,6 +36,7 @@ class API {
 		return array_merge(
 			$args,
 			array(
+				// Needs its own rest base because 'author' is taken.
 				'rest_base'             => 'coauthor',
 				'rest_controller_class' => 'Cata\\CoAuthors_Plus\\API\\CoAuthor_Controller',
 				'show_in_rest'          => true

--- a/includes/api/coauthor-controller/class-coauthor-controller.php
+++ b/includes/api/coauthor-controller/class-coauthor-controller.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * CoAuthor Controller
+ * 
+ * @link https://developer.wordpress.org/reference/classes/wp_rest_terms_controller/
+ * @package Cata\CoAuthors_Plus
+ */
+
+namespace Cata\CoAuthors_Plus\API;
+
+use WP_REST_Terms_Controller;
+use WP_Error;
+use Cata\CoAuthors_Plus\API;
+
+/**
+ * CoAuthor Controller
+ */
+class CoAuthor_Controller extends WP_REST_Terms_Controller {
+
+	/**
+	 * Checks if a given request has access to read posts.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+ 
+		$ask_an_adult = parent::get_items_permissions_check( $request );
+
+		if ( true !== $ask_an_adult ) {
+			return $ask_an_adult;
+		}
+ 
+		return API::current_user_has_cap_cap();
+	}
+
+	/**
+	 * Checks if a given request has access to get a specific item.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
+	 */
+	public function get_item_permissions_check( $request ) {
+
+		$ask_an_adult = parent::get_item_permissions_check( $request );
+
+		if ( true !== $ask_an_adult ) {
+			return $ask_an_adult;
+		}
+
+		return API::current_user_has_cap_cap();
+	}
+
+}

--- a/includes/api/guest-author-controller/class-guest-author-controller.php
+++ b/includes/api/guest-author-controller/class-guest-author-controller.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * CoAuthor Controller
+ * 
+ * @link https://developer.wordpress.org/reference/classes/wp_rest_posts_controller/
+ * @package Cata\CoAuthors_Plus
+ */
+
+namespace Cata\CoAuthors_Plus\API;
+
+use Cata\CoAuthors_Plus\API;
+use WP_Error;
+use WP_REST_Posts_Controller;
+
+class Guest_Author_Controller extends WP_REST_Posts_Controller {
+
+	/**
+	 * Checks if a given request has access to read posts.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		$ask_an_adult = parent::get_items_permissions_check( $request );
+
+		if ( true !== $ask_an_adult ) {
+			return $ask_an_adult;
+		}
+ 
+		return API::current_user_has_cap_cap();   
+	}
+
+	/**
+	 * Checks if a given request has access to read a post.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
+	 */
+	public function get_item_permissions_check( $request ) {
+		$ask_an_adult = parent::get_item_permissions_check( $request );
+
+		if ( true !== $ask_an_adult ) {
+			return $ask_an_adult;
+		}
+
+		return API::current_user_has_cap_cap();
+	}
+
+}

--- a/includes/api/guest-author-controller/class-guest-author-controller.php
+++ b/includes/api/guest-author-controller/class-guest-author-controller.php
@@ -12,6 +12,9 @@ use Cata\CoAuthors_Plus\API;
 use WP_Error;
 use WP_REST_Posts_Controller;
 
+/**
+ * Guest Author Controller
+ */
 class Guest_Author_Controller extends WP_REST_Posts_Controller {
 
 	/**


### PR DESCRIPTION
### Related Issues

- Resolves #12 

### What Was Accomplished

- Added API PHP class
- Added a filter on `register_taxonomy_args` to update the `author` taxonomy added by CoAuthors Plus for inclusion in the REST API.
- Added a filter on `register_post_type_args` to updated the `guest-author` post type added by CoAuthors Plus for inclusion in the REST API.
- Added all relevant Guest Author meta to REST API using `register_post_meta`
  - All fields require Guest Author editing capabilities as defined in CAP.
- Added a filter on `rest_guest-author_query` to allow searching Guest Authors by email.
  - Guest Author editing capabilities are required and querying by `meta_value` is restricted by checking that `meta_key=cap-user_email`.
- Added `CoAuthor_Controller` and `Guest_Author_Controller` classes which extend from `WP_REST_Terms_Controller` and `WP_REST_Posts_Controller` respectively.
  - Their only job so far is to restrict related GET requests to authenticated users with Guest Author editing capabilities.

### How It Was Tested

- [x] Local ( using dev site )
- [x] Staging ( Collective World staging site )

### How To Test

- [x] Clone this branch to your local develoment site
- [x] Install CoAuthors Plus through WordPress admin.
- [x] Create a Guest Author.
- [x] Add an Application Password for yourself.
- [x] Use your Application Password through Basic Auth to authenticate your API tests.

#### Test these API endpoints

- [x] GET `/wp-json/wp/v2/coauthor` lists `author` taxonomy terms.
- [x] GET `/wp-json/wp/v2/coauthor?slug=cap-*` finds the author term associated with the Guest Author you created when `*` is replaced with your Unique Slug / User Nicename.
- [x] GET `/wp-json/wp/v2/coauthor?search=*` finds the author term associated with your Guest Author when `*` is replaced with some portion of your name.
- [x] GET `/wp-json/wp/v2/guest-author/` lists `guest-author` posts.
- [x] GET `/wp-json/wp/v2/guest-author?slug=cap-*`
- [x] GET `/wp-json/wp/v2/guest-author?search=*`
- [x] GET `/wp-json/wp/v2/guest-author?meta_key=cap-user_email&meta_value=*` finds your Guest Author post when `meta_value` is equal to your URL encoded email.
- [x] All of these ^ only work if you're authenticated.