### PR TITLE
Add Tagline, Allow HTML in Tagline and Description

### DIFF
--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -12,7 +12,7 @@
  * Description: Common functions, configuration and compatibility fixes for Co-Authors Plus when used in Cata child themes. Not a fork or replacement for CAP.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.2.2
+ * Version:     0.2.3-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/includes/fields/class-fields.php
+++ b/includes/fields/class-fields.php
@@ -21,6 +21,7 @@ class Fields {
 		'aim',
 		'yahooim',
 		'jabber',
+		'description',
 	);
 
 	/**
@@ -29,59 +30,8 @@ class Fields {
 	public function __construct() {
 		add_filter( 'coauthors_guest_author_fields', array( __CLASS__, 'remove_unused_meta_fields' ) );
 		add_filter( 'coauthors_guest_author_fields', array( __CLASS__, 'add_custom_meta_fields' ), 20, 2 );
-
 		// @priority 20 because CoAuthors_Guest_Authors->action_add_meta_boxes is at 10.
 		add_action( 'add_meta_boxes', array( __CLASS__, 'replace_guest_author_bio_metabox' ), 20, 2 );
-
-	}
-
-	public static function replace_guest_author_bio_metabox() : void {
-		if ( 'guest-author' !== get_post_type() ) {
-			return;
-		}
-		remove_meta_box( 'coauthors-manage-guest-author-bio', 'guest-author', 'normal' );
-		add_meta_box( 'cata-coauthors-manage-guest-author-bio', 'Biographical Info', array( __CLASS__, 'metabox_guest_author_bio' ), 'guest-author', 'normal', 'default' );
-	}
-
-	public static function metabox_guest_author_bio() : void {
-
-		global $post, $coauthors_plus;
-
-		$fields = $coauthors_plus->guest_authors->get_guest_author_fields( 'about' );
-
-		if ( empty( $fields ) ) {
-			return;
-		}
-
-		foreach ( $fields as $field ) {
-
-			$meta_key = 'cap-' . $field['key'];
-			$input_id = 'cata-' . $meta_key;
-			$settings = array(
-				'media_buttons' => false,
-				'textarea_name' => $meta_key,
-				'teeny'         => true,
-				'tinymce'       => array(
-					'theme_advanced_path'               => false,
-					'theme_advanced_statusbar_location' => 'none',
-				),
-				'quicktags'     => array(
-					'buttons' => 'link,em,strong,close',
-				),
-			);
-
-			?>
-			<label for="<?php echo esc_attr( $input_id ) ?>"><?php echo esc_html( $field['label'] ); ?></label>
-			<?php
-
-			wp_editor(
-				get_post_meta( $post->ID, $meta_key, true ),
-				$input_id,
-				$settings
-			);
-
-		}
-
 	}
 
 	/**
@@ -117,33 +67,119 @@ class Fields {
 	 * @return array Updated array of fields.
 	 */
 	public static function add_custom_meta_fields( array $fields_to_return, array $groups ) : array {
-		// Everything is in contact-info for now.
-		// Accept all and contact-info.
-		if ( ! in_array( 'all', $groups, true ) && ! in_array( 'contact-info', $groups, true ) ) {
-			return $fields_to_return;
-		}
 
-		$new_fields = array(
+		$contact_info_fields = array(
 			array(
-				'key'               => 'instagram',
-				'label'             => 'Instagram URL',
-				'group'             => 'contact-info',
-				'sanitize_callback' => 'sanitize_text_field',
+				'key'   => 'instagram',
+				'label' => 'Instagram URL',
+				'group' => 'contact-info',
 			),
 			array(
-				'key'               => 'tiktok',
-				'label'             => 'TikTok URL',
-				'group'             => 'contact-info',
-				'sanitize_callback' => 'sanitize_text_field',
+				'key'   => 'tiktok',
+				'label' => 'TikTok URL',
+				'group' => 'contact-info',
 			),
 			array(
-				'key'               => 'twitter',
-				'label'             => 'Twitter URL',
-				'group'             => 'contact-info',
-				'sanitize_callback' => 'sanitize_text_field',
+				'key'   => 'twitter',
+				'label' => 'Twitter URL',
+				'group' => 'contact-info',
 			),
 		);
 
-		return array_merge( $fields_to_return, $new_fields );
+		$about_fields = array(
+			array(
+				'group'             => 'about',
+				'help_text'         => 'Short description. Approximately 70 - 140 characters. HTML is not included in character count.',
+				'key'               => 'tagline',
+				'label'             => 'Tagline',
+				'sanitize_function' => 'wp_filter_post_kses',
+			),
+			array(
+				'group'             => 'about',
+				'help_text'         => 'Long description. Maximum 400 characters. HTML is not included in character count.',
+				'key'               => 'description',
+				'label'             => __( 'Biographical Info', 'co-authors-plus' ),
+				'sanitize_function' => 'wp_filter_post_kses',
+			),
+		);
+		
+		if ( in_array( 'all', $groups, true ) || in_array( 'contact-info', $groups, true ) ) {
+			$fields_to_return = array_merge( $fields_to_return, $contact_info_fields );
+		}
+
+		if ( in_array( 'all', $groups, true ) || in_array( 'about', $groups, true ) ) {
+			$fields_to_return = array_merge( $fields_to_return, $about_fields );
+		}
+
+		return $fields_to_return;
+	}
+
+	/**
+	 * Replace Guest Author Bio Metabox
+	 */
+	public static function replace_guest_author_bio_metabox() : void {
+		if ( 'guest-author' !== get_post_type() ) {
+			return;
+		}
+		remove_meta_box( 'coauthors-manage-guest-author-bio', 'guest-author', 'normal' );
+		add_meta_box( 'cata-coauthors-manage-guest-author-bio', 'About The Author', array( __CLASS__, 'metabox_guest_author_bio' ), 'guest-author', 'normal', 'default' );
+	}
+
+	/**
+	 * Metabox Guest Author Bio
+	 * 
+	 * @global WP_Post $post
+	 * @global CoAuthors_Plus $coauthors_plus
+	 */
+	public static function metabox_guest_author_bio() : void {
+
+		global $post, $coauthors_plus;
+
+		$fields = $coauthors_plus->guest_authors->get_guest_author_fields( 'about' );
+
+		if ( empty( $fields ) ) {
+			return;
+		}
+		?>
+		<div class="form-wrap">
+			<table class="form-table">
+				<?php foreach ( $fields as $field ) : ?>
+					<?php
+					$meta_key = 'cap-' . $field['key'];
+					$input_id = 'cata-' . $meta_key;
+					$settings = array(
+						'media_buttons' => false,
+						'quicktags'     => array(
+							'buttons' => 'link,em,strong,close',
+						),
+						'textarea_name' => $meta_key,
+						'teeny'         => true,
+						'textarea_rows' => '5',
+						'tinymce'       => false,
+					);  
+					?>
+				<tr>
+					<td>
+						<label for="<?php echo esc_attr( $input_id ); ?>">
+							<strong><?php echo esc_html( $field['label'] ); ?></strong>
+						</label>
+						<?php
+							wp_editor(
+								get_post_meta( $post->ID, $meta_key, true ),
+								$input_id,
+								$settings
+							);
+						?>
+						<?php if ( isset( $field['help_text'] ) ) : ?>
+						<p class="description">
+							<?php echo esc_html( $field['help_text'] ); ?>
+						</p>
+						<?php endif; ?>
+					</td>
+				</tr>
+				<?php endforeach; ?>
+			</table>
+		</div>
+		<?php
 	}
 }


### PR DESCRIPTION
### Related Issues

- Resolves #18 
- Resolves #19 

### What Was Accomplished

- Updated Fields class
  - Added `cap-tagline` field
  - Removed and re-added `cap-description` field to control order of fields in editor.
  - Updated `coauthors-manage-guest-author-bio` metabox callback to provide richtext editing for all Guest Author fields in the the `about` group.
- Updated API class
  - Added `cap-tagline` to meta allowd in REST API.
  - Updated meta data registration so tagline and description use HTML permissive santizing functions.

### How It Was Tested

- [x] Local development environment with new data
- [x] Local site environment with existing data
- [x] Staging site environment with copy of production data

### Screenshots

<img width="918" alt="Screen Shot 2021-09-16 at 9 57 29 AM" src="https://user-images.githubusercontent.com/226381/133632397-b4bbda74-10b9-4b94-8b5f-92e7c27941d4.png">
