### PR TITLE
Add title support to allow creation of Guest Authors via REST API

### DIFF
--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -12,7 +12,7 @@
  * Description: Common functions, configuration and compatibility fixes for Co-Authors Plus when used in Cata child themes. Not a fork or replacement for CAP.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.2.3
+ * Version:     0.2.4-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/includes/api/class-api.php
+++ b/includes/api/class-api.php
@@ -21,7 +21,8 @@ class API {
 		add_filter( 'register_taxonomy_args', array( __CLASS__, 'update_taxonomy_args' ), 10, 2 );
 		add_filter( 'register_post_type_args', array( __CLASS__, 'update_post_type_args' ), 10, 2 );
 		add_action( 'init', array( __CLASS__, 'register_guest_author_meta' ) );
-		add_action( 'do_meta_boxes', array( __CLASS__, 'remove_cutstom_fields_box' ), 10, 0 );
+		// @priority 20 because new CoAuthors_Guest_Authors() happens at default priority.
+		add_action( 'init', array( __CLASS__, 'add_title_support' ), 20 );
 		add_filter( 'rest_guest-author_query', array( __CLASS__, 'post_meta_request_params' ), 10, 2 );
 	}
 
@@ -143,15 +144,6 @@ class API {
 	}
 
 	/**
-	 * Remove Custom Fields Box
-	 * Custom Fields must be enabled to get meta data into the API,
-	 * but we don't actually want it to be edited directly in the post editor.
-	 */
-	public static function remove_cutstom_fields_box() : void {
-		remove_meta_box( 'postcustom', 'guest-author', 'normal' );
-	}
-
-	/**
 	 * Current User Has CAP Capability
 	 * 
 	 * @global CoAuthors_Plus $coauthors_plus
@@ -198,4 +190,14 @@ class API {
 			)
 		);
 	}
+
+	/**
+	 * Add Title Support
+	 * In order for the API to create Guest Authors,
+	 * the post type needs to support the title field.
+	 */
+	public static function add_title_support() : void {
+		add_post_type_support( 'guest-author', 'title' );
+	}
+
 }

--- a/includes/fields/class-fields.php
+++ b/includes/fields/class-fields.php
@@ -32,6 +32,8 @@ class Fields {
 		add_filter( 'coauthors_guest_author_fields', array( __CLASS__, 'add_custom_meta_fields' ), 20, 2 );
 		// @priority 20 because CoAuthors_Guest_Authors->action_add_meta_boxes is at 10.
 		add_action( 'add_meta_boxes', array( __CLASS__, 'replace_guest_author_bio_metabox' ), 20, 2 );
+		add_action( 'do_meta_boxes', array( __CLASS__, 'remove_cutstom_fields_box' ), 10, 0 );
+		add_action( 'edit_form_top', array( __CLASS__, 'remove_title_support' ) );
 	}
 
 	/**
@@ -181,5 +183,22 @@ class Fields {
 			</table>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Remove Custom Fields Box
+	 * Custom Fields must be enabled to get meta data into the API,
+	 * but we don't actually want it to be edited directly in the post editor.
+	 */
+	public static function remove_cutstom_fields_box() : void {
+		remove_meta_box( 'postcustom', 'guest-author', 'normal' );
+	}
+
+	/**
+	 * Remove Title Support
+	 * The API needs title support, but the post editor does not.
+	 */
+	public static function remove_title_support() : void {
+		remove_post_type_support( 'guest-author', 'title' );
 	}
 }


### PR DESCRIPTION
### Related Issues

- Resolves #21 

### What Was Accomplished

- Added an action on `init` to re-add support for `title` in the guest authors custom post type after its been removed in the constructor for `CoAuthors_Guest_Authors`.
- Added an action on `edit_form_top` to remove title support just in time to hide the title field from the post editor.
- Moved the function `remove_cutstom_fields_box` to the Fields class since it has to do with the post editor.

### How It Was Tested

- [x] Created guest authors through post editor and API on Local site.
- [x] Created guest author through API on stagin site.

### Screenshots

#### Guest Author created through post editor

<img width="503" alt="Screen Shot 2021-09-20 at 1 36 47 PM" src="https://user-images.githubusercontent.com/226381/134050343-2b4519ca-9116-4648-a1f4-c36dc2bea748.png">
<img width="1146" alt="Screen Shot 2021-09-20 at 1 36 34 PM" src="https://user-images.githubusercontent.com/226381/134050344-dc26932f-9e76-4424-a62a-47c2d6e70494.png">

#### Guest Author created through API

<img width="1140" alt="Screen Shot 2021-09-20 at 1 40 16 PM" src="https://user-images.githubusercontent.com/226381/134050323-d9456b7d-373c-4bb3-a51b-b78fe8f3014f.png">
<img width="549" alt="Screen Shot 2021-09-20 at 1 39 22 PM" src="https://user-images.githubusercontent.com/226381/134050325-ba65e860-305d-4cf2-b076-8f6b8e0f3e82.png">
I
