### PR TITLE
Use CoAuthor / Guest Author data in oEmbed REST API endpoint

### DIFF
--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -30,6 +30,7 @@ require_once __DIR__ . '/includes/api/coauthor-controller/class-coauthor-control
 require_once __DIR__ . '/includes/api/guest-author-controller/class-guest-author-controller.php';
 require_once __DIR__ . '/includes/jetpack-compat/class-jetpack-compat.php';
 require_once __DIR__ . '/includes/fields/class-fields.php';
+require_once __DIR__ . '/includes/oembed/class-oembed.php';
 
 /**
  * Instantiate Classes
@@ -37,6 +38,7 @@ require_once __DIR__ . '/includes/fields/class-fields.php';
 new Cata\CoAuthors_Plus\API();
 new Cata\CoAuthors_Plus\Fields();
 new Cata\CoAuthors_Plus\Jetpack_Compat();
+new Cata\CoAuthors_Plus\oEmbed();
 
 /**
  * Enable CoAuthors_Template_Filters

--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -12,7 +12,7 @@
  * Description: Common functions, configuration and compatibility fixes for Co-Authors Plus when used in Cata child themes. Not a fork or replacement for CAP.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.2.4
+ * Version:     0.3.0-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/includes/oembed/class-oembed.php
+++ b/includes/oembed/class-oembed.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * oEmbed
+ * 
+ * @package Cata\CoAuthors_Plus
+ * @since
+ */
+
+namespace Cata\CoAuthors_Plus;
+
+use WP_Post;
+
+/**
+ * oEmbed
+ */
+class oEmbed {
+	/**
+	 * Construct
+	 */
+	public function __construct() {
+		add_filter( 'oembed_response_data', array( __CLASS__, 'update_author_data' ), 10, 2 );
+	}
+
+	/**
+	 * Update Author Data
+	 * 
+	 * @global CoAuthors_Plus $coauthors_plus
+	 * @param array $data
+	 * @param WP_Post $post
+	 */
+	public static function update_author_data( array $data, WP_Post $post ) : array {
+		global $coauthors_plus;
+		
+		if ( ! in_array( $post->post_type, $coauthors_plus->supported_post_types, true ) ) {
+			return $data;
+		}
+
+		$coauthors = get_coauthors( $post->ID );
+
+		if ( ! is_array( $coauthors ) || empty( $coauthors ) ) {
+			return $data;
+		}
+
+		$author = current( $coauthors );
+
+		if ( ! isset( $author->ID ) || ! isset( $author->user_nicename ) ) {
+			return $data;
+		}
+
+		return array_merge(
+			$data,
+			array(
+				'author_name' => $author->display_name,
+				'author_url'  => get_author_posts_url( $author->ID, $author->user_nicename ),
+			)
+		);
+	}
+}


### PR DESCRIPTION
### Related Issues
- Resolves #24 

### What Was Accomplished
- Added an oEmbed class that uses a filter on `oembed_response_data` to update oEmbed data with the name and URL of the first available CoAuthor for all post types that support CoAuthors.

### How It Was Tested
- [x] Local site with cata **parent theme**
- [x] Local site with cata **child theme** 
- [x] Staging / Development site with cata **child theme**

### How To Test
- [x] Use the API route `/wp-json/oembed/1.0/embed/?url=` to look up the oEmbed data for a post based on its URL
- [x] If there is a Guest Author assigned to a post, their information should be reflected in the author_name and author_url 