### PR TITLE
CoAuthor Profile in REST API

### DIFF
--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -12,7 +12,7 @@
  * Description: Common functions, configuration and compatibility fixes for Co-Authors Plus when used in Cata child themes. Not a fork or replacement for CAP.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.4.0
+ * Version:     0.4.1-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -12,7 +12,7 @@
  * Description: Common functions, configuration and compatibility fixes for Co-Authors Plus when used in Cata child themes. Not a fork or replacement for CAP.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.4.1-beta1
+ * Version:     0.4.1-beta2
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/includes/api/class-api.php
+++ b/includes/api/class-api.php
@@ -239,7 +239,7 @@ class API {
 						WP_REST_Request::from_url(
 							home_url( "/wp-json/wp/v2/media/{$attachment_id}" )
 						)
-					)
+					)->get_data()
 				);
 			}
 		}

--- a/includes/api/class-api.php
+++ b/includes/api/class-api.php
@@ -8,6 +8,7 @@
 
 namespace Cata\CoAuthors_Plus;
 
+use WP_REST_Response;
 use WP_REST_Request;
 
 /**
@@ -24,6 +25,7 @@ class API {
 		// @priority 20 because new CoAuthors_Guest_Authors() happens at default priority.
 		add_action( 'init', array( __CLASS__, 'add_title_support' ), 20 );
 		add_filter( 'rest_guest-author_query', array( __CLASS__, 'post_meta_request_params' ), 10, 2 );
+		add_filter( 'rest_prepare_author', array( __CLASS__, 'prepare_author_response' ), 10, 3 );
 	}
 
 	/**
@@ -195,6 +197,56 @@ class API {
 	 */
 	public static function add_title_support() : void {
 		add_post_type_support( 'guest-author', 'title' );
+	}
+
+	/**
+	 * Prepare Author Response
+	 * 
+	 * @param WP_REST_Response $response
+	 * @return WP_REST_Response $response
+	 */
+	public static function prepare_author_response( WP_REST_Response $response ) : WP_REST_Response {
+		
+		global $coauthors_plus;
+		
+		$data   = $response->get_data();
+		$author = $coauthors_plus->get_coauthor_by( 'user_nicename', $data['slug'] );
+
+		if ( false === $author || ! ( isset($author->ID) && isset($author->user_nicename) ) ) {
+			return $response;
+		}
+
+		if ( ! isset( $author->type ) ) {
+			return $response;
+		}
+
+		if ( ! in_array( $author->type, array('guest-author', 'wpuser'), true ) ) {
+			return $response;
+		}
+
+		$data['profile'] = array(
+			'display_name' => $author->display_name,
+			'link'         => get_author_posts_url( $author->ID, $author->user_nicename ),
+			'media'        => array()
+		);
+
+		if ( 'guest-author' === $author->type ) {
+			$attachment_id = get_post_thumbnail_id( $author->ID );
+			if ( 0 !== absint( $attachment_id ) ) {
+				array_push(
+					$data['profile']['media'],
+					rest_get_server()->dispatch(
+						WP_REST_Request::from_url(
+							home_url( "/wp-json/wp/v2/media/{$attachment_id}" )
+						)
+					)
+				);
+			}
+		}
+
+		$response->set_data( $data );
+
+		return $response;
 	}
 
 }

--- a/includes/api/coauthor-controller/class-coauthor-controller.php
+++ b/includes/api/coauthor-controller/class-coauthor-controller.php
@@ -30,6 +30,14 @@ class CoAuthor_Controller extends WP_REST_Terms_Controller {
 		if ( true !== $ask_an_adult ) {
 			return $ask_an_adult;
 		}
+
+		/**
+		 * Allow embed context since the sensitive data ( term description )
+		 * is not included.
+		 */
+		if ( 'embed' === $request->get_param('context') ) {
+			return true;
+		}
  
 		return API::current_user_has_cap_cap();
 	}


### PR DESCRIPTION
### Related Issues
- I should have written an issue for this, but it all came together in my exploratory branch.
- We want the coathor data to be publicly available in the REST API when you're embedding a post, but otherwise restricted by capabilities. The embed context already delivers a limited set of data for a any given taxonomy term, so I just needed to add some "profile" data to match our specific use case.

### What Was Accomplished
- Updated the permission callback for the author taxonomy to allow public access in the embed context.
- Added a filter on `rest_prepare_author` that adds a profile property with sub-properties of link, display_name and media.

### How It Was Tested
- [x] Local development environment
- [x] Hosted development environment