### PR TITLE
Bugfix/coauthors rest base

### DIFF
--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -12,7 +12,7 @@
  * Description: Common functions, configuration and compatibility fixes for Co-Authors Plus when used in Cata child themes. Not a fork or replacement for CAP.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.4.1
+ * Version:     0.5.0-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/includes/api/class-api.php
+++ b/includes/api/class-api.php
@@ -43,7 +43,9 @@ class API {
 		return array_merge(
 			$args,
 			array(
+				'rest_base'             => 'coauthor',
 				'rest_controller_class' => 'Cata\\CoAuthors_Plus\\API\\CoAuthor_Controller',
+				'show_in_rest'          => true,
 			)
 		);
 	}


### PR DESCRIPTION
### Related Issues
- Prior to Co-Authors Plus 3.5, the REST API was not available for the author taxonomy, so this plugin was created to make it available.
- When 3.5 was released I updated this plugin for compatibility
  - https://github.com/thoughtis/cata-co-authors-plus/pull/27
- Because of privacy concerns, API support was reverted in 3.5.2
  - https://github.com/Automattic/Co-Authors-Plus/issues/850
- We still need API support, so I am reverting the changes I made to support 3.5

### What Was Accomplished
- Once again show the author taxonomy in the rest API, add our own custom rest base `coauthor`
