### PR TITLE
Remove Web Stories support

### DIFF
--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -44,3 +44,20 @@ new Cata\CoAuthors_Plus\oEmbed();
  * Enable CoAuthors_Template_Filters
  */
 add_filter( 'coauthors_auto_apply_template_tags', '__return_true' );
+
+/**
+ * No Web Stories Support
+ *
+ * @link https://github.com/thoughtis/cata-co-authors-plus/issues/30
+ * @param $post_types Post types supporting the author taxonomy.
+ * @return array Updated array of post types, without web-story.
+ */
+function cata_cap_no_web_stories_support( array $post_types ) : array {
+	return array_values(
+		array_diff(
+			$post_types,
+			array( 'web-story' )
+		)
+	);
+}
+add_filter( 'coauthors_supported_post_types', 'cata_cap_no_web_stories_support' );

--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -12,7 +12,7 @@
  * Description: Common functions, configuration and compatibility fixes for Co-Authors Plus when used in Cata child themes. Not a fork or replacement for CAP.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.5.1-beta1
+ * Version:     0.5.1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -12,7 +12,7 @@
  * Description: Common functions, configuration and compatibility fixes for Co-Authors Plus when used in Cata child themes. Not a fork or replacement for CAP.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.5.0
+ * Version:     0.5.1-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */


### PR DESCRIPTION
### Related Issues
- Resolves #30 

### What Was Accomplished
- Added a filter on `coauthors_supported_post_types` to remove `web-story` from the supported post types.

### How It Was Tested
- [x] Local plugin dev environment
- [x] Local site dev environment
- [x] Remote site dev environment

### How To Test
- [x] Install [Web Stories](https://wordpress.org/plugins/web-stories/)
- [x] Ceate a web story
- [x] Update the author of the web story, ensure the author was saved by reloading the editor.

### Screenshots

I was able to change the author of a web story to Shop Manager
<img width="356" alt="Screen Shot 2022-11-01 at 3 39 53 PM" src="https://user-images.githubusercontent.com/226381/199323597-c6c3fab7-df23-4841-a206-3db2e28c8308.png">

