### PR TITLE
Issue#46/vip image dimensions

### DIFF
--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -37,6 +37,7 @@ require_once __DIR__ . '/includes/editor/classic/class-classic.php';
 require_once __DIR__ . '/includes/jetpack-compat/class-jetpack-compat.php';
 require_once __DIR__ . '/includes/meta-fields/class-meta-fields.php';
 require_once __DIR__ . '/includes/oembed/class-oembed.php';
+require_once __DIR__ . '/includes/vip-compat/class-vip-compat.php';
 
 /**
  * Instantiate Classes
@@ -47,6 +48,7 @@ new Cata\CoAuthors_Plus\API\Block_Schema\Tagline();
 new Cata\CoAuthors_Plus\Jetpack_Compat();
 new Cata\CoAuthors_Plus\Meta_Fields();
 new Cata\CoAuthors_Plus\oEmbed();
+new Cata\CoAuthors_Plus\VIP_Compat();
 
 /**
  * Register Blocks

--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -12,7 +12,7 @@
  * Description: Common functions, configuration and compatibility fixes for Co-Authors Plus when used in Cata child themes. Not a fork or replacement for CAP.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.6.4
+ * Version:     0.6.5-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -12,7 +12,7 @@
  * Description: Common functions, configuration and compatibility fixes for Co-Authors Plus when used in Cata child themes. Not a fork or replacement for CAP.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.6.5-beta2
+ * Version:     0.6.5
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -12,7 +12,7 @@
  * Description: Common functions, configuration and compatibility fixes for Co-Authors Plus when used in Cata child themes. Not a fork or replacement for CAP.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.6.5-beta1
+ * Version:     0.6.5-beta2
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/includes/vip-compat/class-vip-compat.php
+++ b/includes/vip-compat/class-vip-compat.php
@@ -16,7 +16,7 @@ class VIP_Compat {
 	 * Construct
 	 */
 	public function __construct() {
-		add_filter( 'block_editor_settings_all', array( __CLASS__, 'image_sitemap_skip_avatars' ) );
+		add_filter( 'block_editor_settings_all', array( __CLASS__, 'replace_image_dimensions_editor_setting' ) );
 	}
 
 	/**

--- a/includes/vip-compat/class-vip-compat.php
+++ b/includes/vip-compat/class-vip-compat.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * VIP Compat
+ * 
+ * @package Cata\CoAuthors_Plus
+ * @since 0.1.1
+ */
+
+namespace Cata\CoAuthors_Plus;
+
+/**
+ * VIP Compat
+ */
+class VIP_Compat {
+	/**
+	 * Construct
+	 */
+	public function __construct() {
+		add_filter( 'block_editor_settings_all', array( __CLASS__, 'image_sitemap_skip_avatars' ) );
+	}
+
+	/**
+	 * Replace Image Dimensions Editor Setting
+	 * The imageDimensions editor setting is missing because of the removal of intermediate images sizes.
+	 * Bring them back just so we can use theme defined images sizes in the editor.
+	 * This fixes a bug in the Co-Author Featured Image block.
+	 *
+	 * @link https://github.com/Automattic/vip-go-mu-plugins/blob/97c10f8f2f2f871c9a24731a66037962367e2c66/a8c-files.php#L676-L698
+	 * @param array $settings
+	 * @return array $settings
+	 */
+	public static function replace_image_dimensions_editor_setting( array $settings ): array {
+		if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+			return $settings;
+		}
+
+		remove_filter( 'intermediate_image_sizes', 'wpcom_intermediate_sizes' );
+
+		$settings['imageDimensions'] = get_default_block_editor_settings()['imageDimensions'];
+
+		add_filter( 'intermediate_image_sizes', 'wpcom_intermediate_sizes' );
+
+		return $settings;
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cata-co-authors-plus",
-  "version": "0.6.5-beta2",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cata-co-authors-plus",
-      "version": "0.6.5-beta2",
+      "version": "0.6.5",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@wordpress/icons": "^9.49.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cata-co-authors-plus",
-  "version": "0.6.5-beta1",
+  "version": "0.6.5-beta2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cata-co-authors-plus",
-      "version": "0.6.5-beta1",
+      "version": "0.6.5-beta2",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@wordpress/icons": "^9.49.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cata-co-authors-plus",
-  "version": "0.6.4",
+  "version": "0.6.5-beta1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cata-co-authors-plus",
-      "version": "0.6.4",
+      "version": "0.6.5-beta1",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@wordpress/icons": "^9.49.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cata-co-authors-plus",
-  "version": "0.6.4",
+  "version": "0.6.5-beta1",
   "description": "Common functions, configuration and compatibility fixes for Co-Authors Plus when used in Cata child themes. Not a fork or replacement for CAP.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cata-co-authors-plus",
-  "version": "0.6.5-beta2",
+  "version": "0.6.5",
   "description": "Common functions, configuration and compatibility fixes for Co-Authors Plus when used in Cata child themes. Not a fork or replacement for CAP.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cata-co-authors-plus",
-  "version": "0.6.5-beta1",
+  "version": "0.6.5-beta2",
   "description": "Common functions, configuration and compatibility fixes for Co-Authors Plus when used in Cata child themes. Not a fork or replacement for CAP.",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
### Related Issues

- Resolves #46 

### What Was Accomplished

- Added `VIP_Compat` class which filters `block_editor_settings_all` to restore the `imageDimensions` setting.

### How It Was Tested
- [x] Local
- [x] Remote dev environment

### How To Test
#### Local
- [x] Nothing changes

####  VIP remote environments
- [x] Possible to use the Co-Authors Feature Image block
- [x] In query loops where the author is known, the feature image is shown in the editor
- [x] In contexts like the author archive template and single post template, a placeholder is used.