### PR TITLE
Issue#48/autosave

### DIFF
--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -12,7 +12,7 @@
  * Description: Common functions, configuration and compatibility fixes for Co-Authors Plus when used in Cata child themes. Not a fork or replacement for CAP.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.6.5
+ * Version:     0.6.6-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-co-authors-plus.php
+++ b/cata-co-authors-plus.php
@@ -12,7 +12,7 @@
  * Description: Common functions, configuration and compatibility fixes for Co-Authors Plus when used in Cata child themes. Not a fork or replacement for CAP.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.6.6-beta1
+ * Version:     0.6.6
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/includes/editor/class-editor.php
+++ b/includes/editor/class-editor.php
@@ -25,6 +25,7 @@ class Editor {
 	 */
 	public static function add_editor_support() : void {
 		add_post_type_support( 'guest-author', 'editor' );
+		add_post_type_support( 'guest-author', 'autosave' );
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cata-co-authors-plus",
-  "version": "0.6.6-beta1",
+  "version": "0.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cata-co-authors-plus",
-      "version": "0.6.6-beta1",
+      "version": "0.6.6",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@wordpress/icons": "^9.49.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cata-co-authors-plus",
-  "version": "0.6.5",
+  "version": "0.6.6-beta1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cata-co-authors-plus",
-      "version": "0.6.5",
+      "version": "0.6.6-beta1",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@wordpress/icons": "^9.49.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cata-co-authors-plus",
-  "version": "0.6.6-beta1",
+  "version": "0.6.6",
   "description": "Common functions, configuration and compatibility fixes for Co-Authors Plus when used in Cata child themes. Not a fork or replacement for CAP.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cata-co-authors-plus",
-  "version": "0.6.5",
+  "version": "0.6.6-beta1",
   "description": "Common functions, configuration and compatibility fixes for Co-Authors Plus when used in Cata child themes. Not a fork or replacement for CAP.",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
### Related Issue
- Resolves #48 

### What Was Accomplished
- Added support for autosave to guest-author post type.

### How It Was Tested
- [x] Local
- [x] Remote

### How To Test
- [x] Guest Author posts being edited in the block editor can be autosaved.
- [x] When opening a post that was autosaved it doesn't throw an error.